### PR TITLE
refactor: move `math` files to `solvers`

### DIFF
--- a/internal/solvers/algo.go
+++ b/internal/solvers/algo.go
@@ -15,7 +15,7 @@
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-package math
+package solvers
 
 import "log"
 

--- a/internal/solvers/algo_test.go
+++ b/internal/solvers/algo_test.go
@@ -14,7 +14,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-package math
+package solvers
 
 import (
 	"testing"

--- a/internal/solvers/matrix.go
+++ b/internal/solvers/matrix.go
@@ -20,7 +20,7 @@
 // memory access patterns, etc. However if matrices are banded or mostly
 // banded, this code should decently performant.
 
-package math
+package solvers
 
 import (
 	"errors"

--- a/internal/solvers/matrix_test.go
+++ b/internal/solvers/matrix_test.go
@@ -15,7 +15,7 @@
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-package math
+package solvers
 
 import (
 	"reflect"


### PR DESCRIPTION
This is to avoid spending too much time organizing packages and visibility until more structure is needed.