### PR TITLE
chore: make BenchmarkCheckSubsetsForDuplicates fairer

### DIFF
--- a/internal/solvers/data_test.go
+++ b/internal/solvers/data_test.go
@@ -18,6 +18,7 @@
 package solvers
 
 import (
+	"math/rand"
 	"slices"
 	"testing"
 
@@ -63,6 +64,10 @@ func BenchmarkCheckSubsetsForDuplicates(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		// Shuffle to make sure the order of the subsets is not biased.
+		rand.Shuffle(len(subsets), func(i, j int) { subsets[i], subsets[j] = subsets[j], subsets[i] })
+		b.StartTimer()
 		err := checkSubsetsForDuplicates(subsets)
 		assert.NilError(b, err)
 	}


### PR DESCRIPTION
This should make the benchmark less biased.

Before the subsets were sorted by construction in the benchmark which made `checkSubsetsForDuplicates` perform better than expected. This is because `checkSubsetsForDuplicates` as-is sorts the subsets as the first step. Other possible methods could use hash tables instead and wouldn't be sensitive the sorting of the input.