### PR TITLE
feat: add POC Branch-and-Bound solver

### DIFF
--- a/cmd/solve_sc/main.go
+++ b/cmd/solve_sc/main.go
@@ -1,0 +1,83 @@
+/*
+ Copyright (C) 2024 Douglas Wayne Potter
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as
+ published by the Free Software Foundation, either version 3 of the
+ License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// A Branch-and-Bound solver for the "Weighted Exact Cover Problem".
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/snow-abstraction/cover"
+	"github.com/snow-abstraction/cover/internal/solvers"
+)
+
+func usage() {
+	w := flag.CommandLine.Output()
+	fmt.Fprintf(
+		w,
+		`Usage: %s -instance instance.json
+
+%s reads in a problem instance JSON file, solves it and outputs a solution
+to standard out.
+
+Arguments:
+`,
+		os.Args[0],
+		os.Args[0])
+	flag.PrintDefaults()
+}
+
+func main() {
+	flag.Usage = usage
+	filename := flag.String("instance", "", "instance JSON filename")
+	flag.Parse()
+
+	if *filename == "" {
+		log.Fatalln("Please supply the instance file name")
+	}
+
+	b, err := os.ReadFile(*filename)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	var ins cover.Instance
+	err = json.Unmarshal(b, &ins)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	err = json.Unmarshal(b, &ins)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	solverInstance, err := solvers.MakeInstance(ins.M, ins.Subsets, ins.Costs)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	sol, err := solvers.SolveByBranchAndBound(solverInstance)
+	if err != nil {
+		fmt.Printf("failed to optimal solution due to error: %s", err)
+	}
+	fmt.Printf("Solution: %+v\n", sol)
+}

--- a/internal/solvers/brute.go
+++ b/internal/solvers/brute.go
@@ -86,6 +86,7 @@ func SolveByBruteForce(ins instance) (subsetsEval, error) {
 	if ins.m == 0 {
 		return subsetsEval{
 			ExactlyCovered: true,
+			Optimal:        true,
 		}, nil
 	}
 
@@ -117,5 +118,6 @@ func SolveByBruteForce(ins instance) (subsetsEval, error) {
 	}
 
 	slices.Sort(bestSubsetsEval.SubsetsIndices)
+	bestSubsetsEval.Optimal = true
 	return bestSubsetsEval, nil
 }

--- a/internal/solvers/brute_test.go
+++ b/internal/solvers/brute_test.go
@@ -45,7 +45,7 @@ func TestEmptyInstance(t *testing.T) {
 	result, err := SolveByBruteForce(ins)
 	assert.NilError(t, err)
 	//  The result for an empty instance should be a feasible and itself be empty.
-	emptyCover := subsetsEval{ExactlyCovered: true}
+	emptyCover := subsetsEval{ExactlyCovered: true, Optimal: true}
 	assert.DeepEqual(t, result, emptyCover)
 }
 
@@ -54,12 +54,11 @@ func TestCheaperSolutionFound(t *testing.T) {
 	assert.NilError(t, err)
 	result, err := SolveByBruteForce(ins)
 	assert.NilError(t, err)
-	theMinimum := subsetsEval{SubsetsIndices: []int{2, 4}, ExactlyCovered: true, Cost: 7}
+	theMinimum := subsetsEval{SubsetsIndices: []int{2, 4}, ExactlyCovered: true, Cost: 7, Optimal: true}
 	assert.DeepEqual(t, result, theMinimum)
 }
 
 func testBruteFindsEquallyGoodSolution(t *testing.T, spec cover.TestInstanceSpecification) {
-
 	pythonResultBytes, err := os.ReadFile(filepath.Join("../..", spec.PythonSolutionPath))
 	assert.NilError(t, err)
 	var pythonResult map[string]interface{}
@@ -100,7 +99,7 @@ func testBruteFindsEquallyGoodSolution(t *testing.T, spec cover.TestInstanceSpec
 
 }
 
-func TestInstances(t *testing.T) {
+func TestBruteOnInstances(t *testing.T) {
 	instanceSpecifications := loadInstanceSpecifications(t)
 
 	for _, spec := range instanceSpecifications {
@@ -114,7 +113,7 @@ func TestInstances(t *testing.T) {
 	}
 }
 
-func BenchmarkRandomInstances(b *testing.B) {
+func BenchmarkBruteOnRandomInstances(b *testing.B) {
 	instanceSpecifications := loadInstanceSpecifications(b)
 
 	instances := make([]instance, 0, len(instanceSpecifications))
@@ -136,5 +135,4 @@ func BenchmarkRandomInstances(b *testing.B) {
 			assert.NilError(b, err)
 		}
 	}
-
 }

--- a/internal/solvers/data.go
+++ b/internal/solvers/data.go
@@ -106,6 +106,9 @@ type subsetsEval struct {
 	ExactlyCovered bool
 	// The sum of the subsets' costs.
 	Cost float64
+	// If the SubsetsIndices constitute a proven optimum. This can only be true if
+	// ExactlyCovered is true.
+	Optimal bool
 }
 
 func checkSubsetsForDuplicates(subsets [][]int) error {

--- a/internal/tree/nodes.go
+++ b/internal/tree/nodes.go
@@ -39,7 +39,7 @@ const (
 type Node struct {
 	Kind       NodeKind
 	Parent     *Node // nil if root node
-	lowerBound float64
+	LowerBound float64
 	// Elements constrained, depending on NodeKind
 	// The following have no meaning for the root node
 	I uint32


### PR DESCRIPTION
This commits adds a Proof-of-Concept Branch-and-Bound solver for the Exact Set Covering Problem.

Notes:
1. Several important TODOS remain in the code.
2. Around 35% of the cpu time is spent logging according the results from ``` go test ./internal/solvers/  -bench=BenchmarkBBOnRandomInstances -run=^a  -cpuprofile=cpu.out ```