### PR TITLE
perf: mostly adopt slog for logging

### DIFF
--- a/cmd/generate_instance/main.go
+++ b/cmd/generate_instance/main.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/snow-abstraction/cover"
@@ -59,11 +58,13 @@ func main() {
 	flag.Parse()
 
 	if *m < 0 {
-		log.Fatalln("m must be non-negative (0 <= m)")
+		fmt.Fprintln(os.Stderr, "m must be non-negative (0 <= m)")
+		os.Exit(1)
 	}
 
 	if *n < 0 {
-		log.Fatalln("n must be non-negative (0 <= n)")
+		fmt.Fprintln(os.Stderr, "n must be non-negative (0 <= n)")
+		os.Exit(1)
 	}
 
 	if *n > 0 {
@@ -72,8 +73,8 @@ func main() {
 
 	b, err := json.MarshalIndent(ins, "", "  ")
 	if err != nil {
-		log.Fatalln(err)
-
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 	fmt.Println(string(b))
 }

--- a/internal/solvers/algo.go
+++ b/internal/solvers/algo.go
@@ -17,7 +17,7 @@
 
 package solvers
 
-import "log"
+import "log/slog"
 
 type lagrangianDualResult struct {
 	dualObjectiveValue float64
@@ -152,7 +152,7 @@ func runDualIterations(aC cCSMatrix /* C for column storage*/, costs []float64) 
 		if k > nextLogK {
 			nextLogK *= 2
 			objectiveValue := calcObjectiveValue(nCols, costs, x, aR, aRx, nRows, u)
-			log.Printf("Iteration %d Objective value: %f", k, objectiveValue)
+			slog.Debug("Iteration status", "i", k, "objective value", objectiveValue)
 		}
 	}
 

--- a/internal/tree/nodes.go
+++ b/internal/tree/nodes.go
@@ -18,6 +18,8 @@
 package tree
 
 import (
+	"fmt"
+	"log/slog"
 	"math"
 )
 
@@ -61,4 +63,12 @@ func (parent *Node) Branch(lowerBound float64, branchConstraintOne uint32,
 	return &Node{BothBranch, parent, lowerBound, branchConstraintOne, branchConstraintTwo},
 		&Node{DiffBranch, parent, lowerBound, branchConstraintOne, branchConstraintTwo}
 
+}
+
+func (n *Node) LogValue() slog.Value {
+	if n == nil {
+		return slog.StringValue("nil")
+	}
+
+	return slog.StringValue(fmt.Sprintf("%+v", *n))
 }


### PR DESCRIPTION
This is for performance. The adoption of the structured part of `slog` was done hastily.

The package `slog` has logging levels so we can have debug logging in `algo.go` and `bb.go` that we can turn off. Now for when running `BenchmarkBBOnRandomInstances` the logging goes from 35% to not showing up in the profiling.

The classic `log` only remains in
`cmd/generate_test_instances_and_solutions/main.go` since it uses `log.Panic(err)` which is not easily replaced.