### PR TITLE
refactor: rename M to ElementCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ import (
 
 func TestReadMeExample(t *testing.T) {
 	instance := cover.Instance{
-		M:       4,
-		Subsets: [][]int{{0}, {0, 1}, {1, 2}, {1}, {0, 1, 2, 3}, {2, 3}, {0, 1, 3}, {2}},
-		Costs:   []float64{1.8, 1.7, 2.4, 1.4, 5.4, 2.7, 1.9, 1.6}}
+		ElementCount: 4, // This means set of elements to cover is {0, 1, 2 and 3}
+		Subsets:      [][]int{{0}, {0, 1}, {1, 2}, {1}, {0, 1, 2, 3}, {2, 3}, {0, 1, 3}, {2}},
+		Costs:        []float64{1.8, 1.7, 2.4, 1.4, 5.4, 2.7, 1.9, 1.6}}
 
 	result, err := solvers.SolveByBranchAndBound(instance)
 	assert.NilError(t, err)

--- a/data.go
+++ b/data.go
@@ -28,8 +28,8 @@ import (
 
 type Instance struct {
 	// The number of elements in the set X to be covered, indexed
-	// 0 ... M-1.
-	M int
+	// 0 ... ElementCount-1.
+	ElementCount int
 	// Subsets of X. The inner slices must only contain element indices in
 	// [0, M-1]. The indices must be sorted and each subset must be include
 	// at most once. Empty Subsets are not allowed.
@@ -49,18 +49,18 @@ type Instance struct {
 func MakeRandomInstance(m int, n int, costScale float64, seed int64) Instance {
 	gen := rand.New(rand.NewSource(seed))
 
-	ins := Instance{M: m, Subsets: make([][]int, 0), Costs: make([]float64, 0)}
+	ins := Instance{ElementCount: m, Subsets: make([][]int, 0), Costs: make([]float64, 0)}
 
 	// universe of elements to be covered
-	u := make([]int, ins.M)
-	for i := 0; i < ins.M; i++ {
+	u := make([]int, ins.ElementCount)
+	for i := 0; i < ins.ElementCount; i++ {
 		u[i] = i
 	}
 	for j := 0; j < n; j++ {
 		for {
 			// make random subset u[:k]
 			gen.Shuffle(len(u), func(i, j int) { u[i], u[j] = u[j], u[i] })
-			k := gen.Intn(ins.M) + 1
+			k := gen.Intn(ins.ElementCount) + 1
 			subset := u[:k]
 			// sort subset to give it an unique representation
 			sort.Ints(subset)

--- a/internal/doctest/doc_test.go
+++ b/internal/doctest/doc_test.go
@@ -29,9 +29,9 @@ import (
 
 func TestReadMeExample(t *testing.T) {
 	instance := cover.Instance{
-		M:       4,
-		Subsets: [][]int{{0}, {0, 1}, {1, 2}, {1}, {0, 1, 2, 3}, {2, 3}, {0, 1, 3}, {2}},
-		Costs:   []float64{1.8, 1.7, 2.4, 1.4, 5.4, 2.7, 1.9, 1.6}}
+		ElementCount: 4, // This means set of elements to cover is {0, 1, 2 and 3}
+		Subsets:      [][]int{{0}, {0, 1}, {1, 2}, {1}, {0, 1, 2, 3}, {2, 3}, {0, 1, 3}, {2}},
+		Costs:        []float64{1.8, 1.7, 2.4, 1.4, 5.4, 2.7, 1.9, 1.6}}
 
 	result, err := solvers.SolveByBranchAndBound(instance)
 	assert.NilError(t, err)

--- a/internal/solvers/solvers.go
+++ b/internal/solvers/solvers.go
@@ -22,7 +22,7 @@ import "github.com/snow-abstraction/cover"
 // SolveByBranchAndBound exposes an internal method without the suffix `Internal“
 // and takes and returns exported types.
 func SolveByBranchAndBound(ins cover.Instance) (cover.SubsetsEval, error) {
-	solverInstance, err := MakeInstance(ins.M, ins.Subsets, ins.Costs)
+	solverInstance, err := MakeInstance(ins.ElementCount, ins.Subsets, ins.Costs)
 	if err != nil {
 		return cover.SubsetsEval{}, err
 	}
@@ -34,7 +34,7 @@ func SolveByBranchAndBound(ins cover.Instance) (cover.SubsetsEval, error) {
 // SolveByBruteForce exposes an internal method without the suffix `Internal“
 // and takes and returns exported types.
 func SolveByBruteForce(ins cover.Instance) (cover.SubsetsEval, error) {
-	solverInstance, err := MakeInstance(ins.M, ins.Subsets, ins.Costs)
+	solverInstance, err := MakeInstance(ins.ElementCount, ins.Subsets, ins.Costs)
 	if err != nil {
 		return cover.SubsetsEval{}, err
 	}

--- a/internal/solvers/test_util.go
+++ b/internal/solvers/test_util.go
@@ -47,7 +47,7 @@ func loadSmallInstanceSpecifications(t testing.TB) []cover.TestInstanceSpecifica
 func loadSolverInstance(t testing.TB, jsonInstancePath string) instance {
 	ins, err := cover.ReadJsonInstance(jsonInstancePath)
 	assert.NilError(t, err)
-	solverInstance, err := MakeInstance(ins.M, ins.Subsets, ins.Costs)
+	solverInstance, err := MakeInstance(ins.ElementCount, ins.Subsets, ins.Costs)
 	assert.NilError(t, err)
 	return solverInstance
 }

--- a/readMPS.go
+++ b/readMPS.go
@@ -98,7 +98,7 @@ func ReadMPSInstance(filename string) (*Instance, error) {
 				return nil, fmt.Errorf("ROW name '%s' duplicated", fields[0])
 			}
 			rows[fields[1]] = len(rows)
-			ins.M++
+			ins.ElementCount++
 		case MPS_SECTION_COLUMNS:
 			if !foundCostRow {
 				return nil, fmt.Errorf("expected cost row to be found before COLUMN section")
@@ -211,8 +211,8 @@ func ReadMPSInstance(filename string) (*Instance, error) {
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-	if rhsCount != ins.M {
-		return nil, fmt.Errorf("rhsCount (%d) != ins.m (%d)", rhsCount, ins.M)
+	if rhsCount != ins.ElementCount {
+		return nil, fmt.Errorf("rhsCount (%d) != ins.m (%d)", rhsCount, ins.ElementCount)
 	}
 	if upperBoundCount != len(ins.Subsets) {
 		return nil, fmt.Errorf("upperBoundCount (%d) != len(ins.Subsets) (%d)", upperBoundCount, len(ins.Subsets))

--- a/testdata/instances/instance_10_100_1000_2.json
+++ b/testdata/instances/instance_10_100_1000_2.json
@@ -1,5 +1,5 @@
 {
-  "M": 10,
+  "ElementCount": 10,
   "Subsets": [
     [
       3,

--- a/testdata/instances/instance_10_100_1000_3.json
+++ b/testdata/instances/instance_10_100_1000_3.json
@@ -1,5 +1,5 @@
 {
-  "M": 10,
+  "ElementCount": 10,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_15_225_1000_4.json
+++ b/testdata/instances/instance_15_225_1000_4.json
@@ -1,5 +1,5 @@
 {
-  "M": 15,
+  "ElementCount": 15,
   "Subsets": [
     [
       5

--- a/testdata/instances/instance_15_225_1000_5.json
+++ b/testdata/instances/instance_15_225_1000_5.json
@@ -1,5 +1,5 @@
 {
-  "M": 15,
+  "ElementCount": 15,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_1_1_1000_0.json
+++ b/testdata/instances/instance_1_1_1000_0.json
@@ -1,5 +1,5 @@
 {
-  "M": 1,
+  "ElementCount": 1,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_1_1_1000_1.json
+++ b/testdata/instances/instance_1_1_1000_1.json
@@ -1,5 +1,5 @@
 {
-  "M": 1,
+  "ElementCount": 1,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_1_1_1_0.json
+++ b/testdata/instances/instance_1_1_1_0.json
@@ -1,5 +1,5 @@
 {
-  "M": 1,
+  "ElementCount": 1,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_1_1_1_1.json
+++ b/testdata/instances/instance_1_1_1_1.json
@@ -1,5 +1,5 @@
 {
-  "M": 1,
+  "ElementCount": 1,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_1_1000_2.json
+++ b/testdata/instances/instance_2_1_1000_2.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_1_1000_3.json
+++ b/testdata/instances/instance_2_1_1000_3.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_1_1000_4.json
+++ b/testdata/instances/instance_2_1_1000_4.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_1_1000_5.json
+++ b/testdata/instances/instance_2_1_1000_5.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_1_1000_6.json
+++ b/testdata/instances/instance_2_1_1000_6.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_1_1000_7.json
+++ b/testdata/instances/instance_2_1_1000_7.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_1_1000_8.json
+++ b/testdata/instances/instance_2_1_1000_8.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_1_1000_9.json
+++ b/testdata/instances/instance_2_1_1000_9.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_1_1_2.json
+++ b/testdata/instances/instance_2_1_1_2.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_1_1_3.json
+++ b/testdata/instances/instance_2_1_1_3.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_1_1_4.json
+++ b/testdata/instances/instance_2_1_1_4.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_1_1_5.json
+++ b/testdata/instances/instance_2_1_1_5.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_1_1_6.json
+++ b/testdata/instances/instance_2_1_1_6.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_1_1_7.json
+++ b/testdata/instances/instance_2_1_1_7.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_1_1_8.json
+++ b/testdata/instances/instance_2_1_1_8.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_1_1_9.json
+++ b/testdata/instances/instance_2_1_1_9.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_2_1000_10.json
+++ b/testdata/instances/instance_2_2_1000_10.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_2_1000_11.json
+++ b/testdata/instances/instance_2_2_1000_11.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_2_1000_12.json
+++ b/testdata/instances/instance_2_2_1000_12.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_2_1000_13.json
+++ b/testdata/instances/instance_2_2_1000_13.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_2_1000_14.json
+++ b/testdata/instances/instance_2_2_1000_14.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_2_1000_4.json
+++ b/testdata/instances/instance_2_2_1000_4.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_2_1000_5.json
+++ b/testdata/instances/instance_2_2_1000_5.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_2_1000_7.json
+++ b/testdata/instances/instance_2_2_1000_7.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_2_1000_8.json
+++ b/testdata/instances/instance_2_2_1000_8.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_2_1000_9.json
+++ b/testdata/instances/instance_2_2_1000_9.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_2_1_10.json
+++ b/testdata/instances/instance_2_2_1_10.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_2_1_11.json
+++ b/testdata/instances/instance_2_2_1_11.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_2_1_12.json
+++ b/testdata/instances/instance_2_2_1_12.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_2_1_13.json
+++ b/testdata/instances/instance_2_2_1_13.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_2_1_14.json
+++ b/testdata/instances/instance_2_2_1_14.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_2_1_4.json
+++ b/testdata/instances/instance_2_2_1_4.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_2_1_5.json
+++ b/testdata/instances/instance_2_2_1_5.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_2_1_7.json
+++ b/testdata/instances/instance_2_2_1_7.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_2_1_8.json
+++ b/testdata/instances/instance_2_2_1_8.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_2_1_9.json
+++ b/testdata/instances/instance_2_2_1_9.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_3_1000_12.json
+++ b/testdata/instances/instance_2_3_1000_12.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_3_1000_13.json
+++ b/testdata/instances/instance_2_3_1000_13.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_3_1000_14.json
+++ b/testdata/instances/instance_2_3_1000_14.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_3_1000_15.json
+++ b/testdata/instances/instance_2_3_1000_15.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_3_1000_16.json
+++ b/testdata/instances/instance_2_3_1000_16.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_3_1000_17.json
+++ b/testdata/instances/instance_2_3_1000_17.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_3_1000_18.json
+++ b/testdata/instances/instance_2_3_1000_18.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_3_1000_19.json
+++ b/testdata/instances/instance_2_3_1000_19.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_3_1000_6.json
+++ b/testdata/instances/instance_2_3_1000_6.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_3_1000_7.json
+++ b/testdata/instances/instance_2_3_1000_7.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_3_1_12.json
+++ b/testdata/instances/instance_2_3_1_12.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_3_1_13.json
+++ b/testdata/instances/instance_2_3_1_13.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_3_1_14.json
+++ b/testdata/instances/instance_2_3_1_14.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_3_1_15.json
+++ b/testdata/instances/instance_2_3_1_15.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_3_1_16.json
+++ b/testdata/instances/instance_2_3_1_16.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_3_1_17.json
+++ b/testdata/instances/instance_2_3_1_17.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_3_1_18.json
+++ b/testdata/instances/instance_2_3_1_18.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_2_3_1_19.json
+++ b/testdata/instances/instance_2_3_1_19.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_2_3_1_6.json
+++ b/testdata/instances/instance_2_3_1_6.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_2_3_1_7.json
+++ b/testdata/instances/instance_2_3_1_7.json
@@ -1,5 +1,5 @@
 {
-  "M": 2,
+  "ElementCount": 2,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_1_1000_17.json
+++ b/testdata/instances/instance_3_1_1000_17.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_1_1000_18.json
+++ b/testdata/instances/instance_3_1_1000_18.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_1_1000_19.json
+++ b/testdata/instances/instance_3_1_1000_19.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_1_1000_20.json
+++ b/testdata/instances/instance_3_1_1000_20.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_1_1000_21.json
+++ b/testdata/instances/instance_3_1_1000_21.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_1_1000_22.json
+++ b/testdata/instances/instance_3_1_1000_22.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_1_1000_23.json
+++ b/testdata/instances/instance_3_1_1000_23.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_1_1000_24.json
+++ b/testdata/instances/instance_3_1_1000_24.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_1_1000_8.json
+++ b/testdata/instances/instance_3_1_1000_8.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_1_1000_9.json
+++ b/testdata/instances/instance_3_1_1000_9.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_1_1_17.json
+++ b/testdata/instances/instance_3_1_1_17.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_1_1_18.json
+++ b/testdata/instances/instance_3_1_1_18.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_1_1_19.json
+++ b/testdata/instances/instance_3_1_1_19.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_1_1_20.json
+++ b/testdata/instances/instance_3_1_1_20.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_1_1_21.json
+++ b/testdata/instances/instance_3_1_1_21.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_1_1_22.json
+++ b/testdata/instances/instance_3_1_1_22.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_1_1_23.json
+++ b/testdata/instances/instance_3_1_1_23.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_1_1_24.json
+++ b/testdata/instances/instance_3_1_1_24.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_1_1_8.json
+++ b/testdata/instances/instance_3_1_1_8.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_1_1_9.json
+++ b/testdata/instances/instance_3_1_1_9.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_2_1000_10.json
+++ b/testdata/instances/instance_3_2_1000_10.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1000_11.json
+++ b/testdata/instances/instance_3_2_1000_11.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1000_22.json
+++ b/testdata/instances/instance_3_2_1000_22.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_2_1000_23.json
+++ b/testdata/instances/instance_3_2_1000_23.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1000_24.json
+++ b/testdata/instances/instance_3_2_1000_24.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1000_25.json
+++ b/testdata/instances/instance_3_2_1000_25.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1000_26.json
+++ b/testdata/instances/instance_3_2_1000_26.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_2_1000_27.json
+++ b/testdata/instances/instance_3_2_1000_27.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1000_28.json
+++ b/testdata/instances/instance_3_2_1000_28.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1000_29.json
+++ b/testdata/instances/instance_3_2_1000_29.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_3_2_1_10.json
+++ b/testdata/instances/instance_3_2_1_10.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1_11.json
+++ b/testdata/instances/instance_3_2_1_11.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1_22.json
+++ b/testdata/instances/instance_3_2_1_22.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_2_1_23.json
+++ b/testdata/instances/instance_3_2_1_23.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1_24.json
+++ b/testdata/instances/instance_3_2_1_24.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1_25.json
+++ b/testdata/instances/instance_3_2_1_25.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1_26.json
+++ b/testdata/instances/instance_3_2_1_26.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_2_1_27.json
+++ b/testdata/instances/instance_3_2_1_27.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1_28.json
+++ b/testdata/instances/instance_3_2_1_28.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_2_1_29.json
+++ b/testdata/instances/instance_3_2_1_29.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_3_3_1000_12.json
+++ b/testdata/instances/instance_3_3_1000_12.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1000_13.json
+++ b/testdata/instances/instance_3_3_1000_13.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_3_3_1000_27.json
+++ b/testdata/instances/instance_3_3_1000_27.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1000_28.json
+++ b/testdata/instances/instance_3_3_1000_28.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1000_29.json
+++ b/testdata/instances/instance_3_3_1000_29.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_3_3_1000_30.json
+++ b/testdata/instances/instance_3_3_1000_30.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1000_31.json
+++ b/testdata/instances/instance_3_3_1000_31.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1000_32.json
+++ b/testdata/instances/instance_3_3_1000_32.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1000_33.json
+++ b/testdata/instances/instance_3_3_1000_33.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_3_1000_34.json
+++ b/testdata/instances/instance_3_3_1000_34.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_3_1_12.json
+++ b/testdata/instances/instance_3_3_1_12.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1_13.json
+++ b/testdata/instances/instance_3_3_1_13.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_3_3_1_27.json
+++ b/testdata/instances/instance_3_3_1_27.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1_28.json
+++ b/testdata/instances/instance_3_3_1_28.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1_29.json
+++ b/testdata/instances/instance_3_3_1_29.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_3_3_1_30.json
+++ b/testdata/instances/instance_3_3_1_30.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1_31.json
+++ b/testdata/instances/instance_3_3_1_31.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1_32.json
+++ b/testdata/instances/instance_3_3_1_32.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_3_1_33.json
+++ b/testdata/instances/instance_3_3_1_33.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_3_1_34.json
+++ b/testdata/instances/instance_3_3_1_34.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_4_1000_14.json
+++ b/testdata/instances/instance_3_4_1000_14.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_4_1000_15.json
+++ b/testdata/instances/instance_3_4_1000_15.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_4_1000_32.json
+++ b/testdata/instances/instance_3_4_1000_32.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_4_1000_33.json
+++ b/testdata/instances/instance_3_4_1000_33.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_4_1000_34.json
+++ b/testdata/instances/instance_3_4_1000_34.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_4_1000_35.json
+++ b/testdata/instances/instance_3_4_1000_35.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_3_4_1000_36.json
+++ b/testdata/instances/instance_3_4_1000_36.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_4_1000_37.json
+++ b/testdata/instances/instance_3_4_1000_37.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_4_1000_38.json
+++ b/testdata/instances/instance_3_4_1000_38.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_4_1000_39.json
+++ b/testdata/instances/instance_3_4_1000_39.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_4_1_14.json
+++ b/testdata/instances/instance_3_4_1_14.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_4_1_15.json
+++ b/testdata/instances/instance_3_4_1_15.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_4_1_32.json
+++ b/testdata/instances/instance_3_4_1_32.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_4_1_33.json
+++ b/testdata/instances/instance_3_4_1_33.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_4_1_34.json
+++ b/testdata/instances/instance_3_4_1_34.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_4_1_35.json
+++ b/testdata/instances/instance_3_4_1_35.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_3_4_1_36.json
+++ b/testdata/instances/instance_3_4_1_36.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_4_1_37.json
+++ b/testdata/instances/instance_3_4_1_37.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_4_1_38.json
+++ b/testdata/instances/instance_3_4_1_38.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_4_1_39.json
+++ b/testdata/instances/instance_3_4_1_39.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_5_1000_16.json
+++ b/testdata/instances/instance_3_5_1000_16.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1000_17.json
+++ b/testdata/instances/instance_3_5_1000_17.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1000_37.json
+++ b/testdata/instances/instance_3_5_1000_37.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1000_38.json
+++ b/testdata/instances/instance_3_5_1000_38.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1000_39.json
+++ b/testdata/instances/instance_3_5_1000_39.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_5_1000_40.json
+++ b/testdata/instances/instance_3_5_1000_40.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_3_5_1000_41.json
+++ b/testdata/instances/instance_3_5_1000_41.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1000_42.json
+++ b/testdata/instances/instance_3_5_1000_42.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1000_43.json
+++ b/testdata/instances/instance_3_5_1000_43.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1000_44.json
+++ b/testdata/instances/instance_3_5_1000_44.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1_16.json
+++ b/testdata/instances/instance_3_5_1_16.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1_17.json
+++ b/testdata/instances/instance_3_5_1_17.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1_37.json
+++ b/testdata/instances/instance_3_5_1_37.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1_38.json
+++ b/testdata/instances/instance_3_5_1_38.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1_39.json
+++ b/testdata/instances/instance_3_5_1_39.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_5_1_40.json
+++ b/testdata/instances/instance_3_5_1_40.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_3_5_1_41.json
+++ b/testdata/instances/instance_3_5_1_41.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1_42.json
+++ b/testdata/instances/instance_3_5_1_42.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1_43.json
+++ b/testdata/instances/instance_3_5_1_43.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_5_1_44.json
+++ b/testdata/instances/instance_3_5_1_44.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1000_18.json
+++ b/testdata/instances/instance_3_6_1000_18.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_6_1000_19.json
+++ b/testdata/instances/instance_3_6_1000_19.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_6_1000_42.json
+++ b/testdata/instances/instance_3_6_1000_42.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1000_43.json
+++ b/testdata/instances/instance_3_6_1000_43.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1000_44.json
+++ b/testdata/instances/instance_3_6_1000_44.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1000_45.json
+++ b/testdata/instances/instance_3_6_1000_45.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_3_6_1000_46.json
+++ b/testdata/instances/instance_3_6_1000_46.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1000_47.json
+++ b/testdata/instances/instance_3_6_1000_47.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_6_1000_48.json
+++ b/testdata/instances/instance_3_6_1000_48.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1000_49.json
+++ b/testdata/instances/instance_3_6_1000_49.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_6_1_18.json
+++ b/testdata/instances/instance_3_6_1_18.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_6_1_19.json
+++ b/testdata/instances/instance_3_6_1_19.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_3_6_1_42.json
+++ b/testdata/instances/instance_3_6_1_42.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1_43.json
+++ b/testdata/instances/instance_3_6_1_43.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1_44.json
+++ b/testdata/instances/instance_3_6_1_44.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1_45.json
+++ b/testdata/instances/instance_3_6_1_45.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_3_6_1_46.json
+++ b/testdata/instances/instance_3_6_1_46.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1_47.json
+++ b/testdata/instances/instance_3_6_1_47.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_3_6_1_48.json
+++ b/testdata/instances/instance_3_6_1_48.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_3_6_1_49.json
+++ b/testdata/instances/instance_3_6_1_49.json
@@ -1,5 +1,5 @@
 {
-  "M": 3,
+  "ElementCount": 3,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_4_10_1000_38.json
+++ b/testdata/instances/instance_4_10_1000_38.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_10_1000_39.json
+++ b/testdata/instances/instance_4_10_1000_39.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_10_1000_92.json
+++ b/testdata/instances/instance_4_10_1000_92.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_10_1000_93.json
+++ b/testdata/instances/instance_4_10_1000_93.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_10_1000_94.json
+++ b/testdata/instances/instance_4_10_1000_94.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_10_1000_95.json
+++ b/testdata/instances/instance_4_10_1000_95.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_10_1000_96.json
+++ b/testdata/instances/instance_4_10_1000_96.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_10_1000_97.json
+++ b/testdata/instances/instance_4_10_1000_97.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_10_1000_98.json
+++ b/testdata/instances/instance_4_10_1000_98.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_10_1000_99.json
+++ b/testdata/instances/instance_4_10_1000_99.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_10_1_38.json
+++ b/testdata/instances/instance_4_10_1_38.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_10_1_39.json
+++ b/testdata/instances/instance_4_10_1_39.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_10_1_92.json
+++ b/testdata/instances/instance_4_10_1_92.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_10_1_93.json
+++ b/testdata/instances/instance_4_10_1_93.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_10_1_94.json
+++ b/testdata/instances/instance_4_10_1_94.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_10_1_95.json
+++ b/testdata/instances/instance_4_10_1_95.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_10_1_96.json
+++ b/testdata/instances/instance_4_10_1_96.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_10_1_97.json
+++ b/testdata/instances/instance_4_10_1_97.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_10_1_98.json
+++ b/testdata/instances/instance_4_10_1_98.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_10_1_99.json
+++ b/testdata/instances/instance_4_10_1_99.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_11_1000_100.json
+++ b/testdata/instances/instance_4_11_1000_100.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_11_1000_101.json
+++ b/testdata/instances/instance_4_11_1000_101.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_11_1000_102.json
+++ b/testdata/instances/instance_4_11_1000_102.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_11_1000_103.json
+++ b/testdata/instances/instance_4_11_1000_103.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_11_1000_104.json
+++ b/testdata/instances/instance_4_11_1000_104.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_11_1000_40.json
+++ b/testdata/instances/instance_4_11_1000_40.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_11_1000_41.json
+++ b/testdata/instances/instance_4_11_1000_41.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_11_1000_97.json
+++ b/testdata/instances/instance_4_11_1000_97.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_11_1000_98.json
+++ b/testdata/instances/instance_4_11_1000_98.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_11_1000_99.json
+++ b/testdata/instances/instance_4_11_1000_99.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_11_1_100.json
+++ b/testdata/instances/instance_4_11_1_100.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_11_1_101.json
+++ b/testdata/instances/instance_4_11_1_101.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_11_1_102.json
+++ b/testdata/instances/instance_4_11_1_102.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_11_1_103.json
+++ b/testdata/instances/instance_4_11_1_103.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_11_1_104.json
+++ b/testdata/instances/instance_4_11_1_104.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_11_1_40.json
+++ b/testdata/instances/instance_4_11_1_40.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_11_1_41.json
+++ b/testdata/instances/instance_4_11_1_41.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_11_1_97.json
+++ b/testdata/instances/instance_4_11_1_97.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_11_1_98.json
+++ b/testdata/instances/instance_4_11_1_98.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_11_1_99.json
+++ b/testdata/instances/instance_4_11_1_99.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1000_102.json
+++ b/testdata/instances/instance_4_12_1000_102.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1000_103.json
+++ b/testdata/instances/instance_4_12_1000_103.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_12_1000_104.json
+++ b/testdata/instances/instance_4_12_1000_104.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_12_1000_105.json
+++ b/testdata/instances/instance_4_12_1000_105.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1000_106.json
+++ b/testdata/instances/instance_4_12_1000_106.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_4_12_1000_107.json
+++ b/testdata/instances/instance_4_12_1000_107.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1000_108.json
+++ b/testdata/instances/instance_4_12_1000_108.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1000_109.json
+++ b/testdata/instances/instance_4_12_1000_109.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_4_12_1000_42.json
+++ b/testdata/instances/instance_4_12_1000_42.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1000_43.json
+++ b/testdata/instances/instance_4_12_1000_43.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1_102.json
+++ b/testdata/instances/instance_4_12_1_102.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1_103.json
+++ b/testdata/instances/instance_4_12_1_103.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_12_1_104.json
+++ b/testdata/instances/instance_4_12_1_104.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_12_1_105.json
+++ b/testdata/instances/instance_4_12_1_105.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1_106.json
+++ b/testdata/instances/instance_4_12_1_106.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_4_12_1_107.json
+++ b/testdata/instances/instance_4_12_1_107.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1_108.json
+++ b/testdata/instances/instance_4_12_1_108.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1_109.json
+++ b/testdata/instances/instance_4_12_1_109.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_4_12_1_42.json
+++ b/testdata/instances/instance_4_12_1_42.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_12_1_43.json
+++ b/testdata/instances/instance_4_12_1_43.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_1_1000_20.json
+++ b/testdata/instances/instance_4_1_1000_20.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_1_1000_21.json
+++ b/testdata/instances/instance_4_1_1000_21.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_1_1000_47.json
+++ b/testdata/instances/instance_4_1_1000_47.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_1_1000_48.json
+++ b/testdata/instances/instance_4_1_1000_48.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_1_1000_49.json
+++ b/testdata/instances/instance_4_1_1000_49.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_4_1_1000_50.json
+++ b/testdata/instances/instance_4_1_1000_50.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_1_1000_51.json
+++ b/testdata/instances/instance_4_1_1000_51.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_1_1000_52.json
+++ b/testdata/instances/instance_4_1_1000_52.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_1_1000_53.json
+++ b/testdata/instances/instance_4_1_1000_53.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_4_1_1000_54.json
+++ b/testdata/instances/instance_4_1_1000_54.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_1_1_20.json
+++ b/testdata/instances/instance_4_1_1_20.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_1_1_21.json
+++ b/testdata/instances/instance_4_1_1_21.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_1_1_47.json
+++ b/testdata/instances/instance_4_1_1_47.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_1_1_48.json
+++ b/testdata/instances/instance_4_1_1_48.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_1_1_49.json
+++ b/testdata/instances/instance_4_1_1_49.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_4_1_1_50.json
+++ b/testdata/instances/instance_4_1_1_50.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_1_1_51.json
+++ b/testdata/instances/instance_4_1_1_51.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_1_1_52.json
+++ b/testdata/instances/instance_4_1_1_52.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_1_1_53.json
+++ b/testdata/instances/instance_4_1_1_53.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_4_1_1_54.json
+++ b/testdata/instances/instance_4_1_1_54.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_2_1000_22.json
+++ b/testdata/instances/instance_4_2_1000_22.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_2_1000_23.json
+++ b/testdata/instances/instance_4_2_1000_23.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_2_1000_52.json
+++ b/testdata/instances/instance_4_2_1000_52.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_2_1000_53.json
+++ b/testdata/instances/instance_4_2_1000_53.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_4_2_1000_54.json
+++ b/testdata/instances/instance_4_2_1000_54.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_2_1000_55.json
+++ b/testdata/instances/instance_4_2_1000_55.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_2_1000_56.json
+++ b/testdata/instances/instance_4_2_1000_56.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_2_1000_57.json
+++ b/testdata/instances/instance_4_2_1000_57.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_2_1000_58.json
+++ b/testdata/instances/instance_4_2_1000_58.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_2_1000_59.json
+++ b/testdata/instances/instance_4_2_1000_59.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_2_1_22.json
+++ b/testdata/instances/instance_4_2_1_22.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_2_1_23.json
+++ b/testdata/instances/instance_4_2_1_23.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_2_1_52.json
+++ b/testdata/instances/instance_4_2_1_52.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_2_1_53.json
+++ b/testdata/instances/instance_4_2_1_53.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_4_2_1_54.json
+++ b/testdata/instances/instance_4_2_1_54.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_2_1_55.json
+++ b/testdata/instances/instance_4_2_1_55.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_2_1_56.json
+++ b/testdata/instances/instance_4_2_1_56.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_2_1_57.json
+++ b/testdata/instances/instance_4_2_1_57.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_2_1_58.json
+++ b/testdata/instances/instance_4_2_1_58.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_2_1_59.json
+++ b/testdata/instances/instance_4_2_1_59.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1000_24.json
+++ b/testdata/instances/instance_4_3_1000_24.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1000_25.json
+++ b/testdata/instances/instance_4_3_1000_25.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1000_57.json
+++ b/testdata/instances/instance_4_3_1000_57.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1000_58.json
+++ b/testdata/instances/instance_4_3_1000_58.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1000_59.json
+++ b/testdata/instances/instance_4_3_1000_59.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1000_60.json
+++ b/testdata/instances/instance_4_3_1000_60.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1000_61.json
+++ b/testdata/instances/instance_4_3_1000_61.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1000_62.json
+++ b/testdata/instances/instance_4_3_1000_62.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1000_63.json
+++ b/testdata/instances/instance_4_3_1000_63.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_3_1000_64.json
+++ b/testdata/instances/instance_4_3_1000_64.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_3_1_24.json
+++ b/testdata/instances/instance_4_3_1_24.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1_25.json
+++ b/testdata/instances/instance_4_3_1_25.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1_57.json
+++ b/testdata/instances/instance_4_3_1_57.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1_58.json
+++ b/testdata/instances/instance_4_3_1_58.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1_59.json
+++ b/testdata/instances/instance_4_3_1_59.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1_60.json
+++ b/testdata/instances/instance_4_3_1_60.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1_61.json
+++ b/testdata/instances/instance_4_3_1_61.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1_62.json
+++ b/testdata/instances/instance_4_3_1_62.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_3_1_63.json
+++ b/testdata/instances/instance_4_3_1_63.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_3_1_64.json
+++ b/testdata/instances/instance_4_3_1_64.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_4_1000_26.json
+++ b/testdata/instances/instance_4_4_1000_26.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1000_27.json
+++ b/testdata/instances/instance_4_4_1000_27.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_4_1000_62.json
+++ b/testdata/instances/instance_4_4_1000_62.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1000_63.json
+++ b/testdata/instances/instance_4_4_1000_63.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_4_1000_64.json
+++ b/testdata/instances/instance_4_4_1000_64.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_4_1000_65.json
+++ b/testdata/instances/instance_4_4_1000_65.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_4_1000_66.json
+++ b/testdata/instances/instance_4_4_1000_66.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1000_67.json
+++ b/testdata/instances/instance_4_4_1000_67.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1000_68.json
+++ b/testdata/instances/instance_4_4_1000_68.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1000_69.json
+++ b/testdata/instances/instance_4_4_1000_69.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1_26.json
+++ b/testdata/instances/instance_4_4_1_26.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1_27.json
+++ b/testdata/instances/instance_4_4_1_27.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_4_1_62.json
+++ b/testdata/instances/instance_4_4_1_62.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1_63.json
+++ b/testdata/instances/instance_4_4_1_63.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_4_1_64.json
+++ b/testdata/instances/instance_4_4_1_64.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_4_1_65.json
+++ b/testdata/instances/instance_4_4_1_65.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_4_1_66.json
+++ b/testdata/instances/instance_4_4_1_66.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1_67.json
+++ b/testdata/instances/instance_4_4_1_67.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1_68.json
+++ b/testdata/instances/instance_4_4_1_68.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_4_1_69.json
+++ b/testdata/instances/instance_4_4_1_69.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_5_1000_28.json
+++ b/testdata/instances/instance_4_5_1000_28.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_5_1000_29.json
+++ b/testdata/instances/instance_4_5_1000_29.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_5_1000_67.json
+++ b/testdata/instances/instance_4_5_1000_67.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_5_1000_68.json
+++ b/testdata/instances/instance_4_5_1000_68.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_5_1000_69.json
+++ b/testdata/instances/instance_4_5_1000_69.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_5_1000_70.json
+++ b/testdata/instances/instance_4_5_1000_70.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_5_1000_71.json
+++ b/testdata/instances/instance_4_5_1000_71.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_4_5_1000_72.json
+++ b/testdata/instances/instance_4_5_1000_72.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_5_1000_73.json
+++ b/testdata/instances/instance_4_5_1000_73.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_5_1000_74.json
+++ b/testdata/instances/instance_4_5_1000_74.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_5_1_28.json
+++ b/testdata/instances/instance_4_5_1_28.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_5_1_29.json
+++ b/testdata/instances/instance_4_5_1_29.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_5_1_67.json
+++ b/testdata/instances/instance_4_5_1_67.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_5_1_68.json
+++ b/testdata/instances/instance_4_5_1_68.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_5_1_69.json
+++ b/testdata/instances/instance_4_5_1_69.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_5_1_70.json
+++ b/testdata/instances/instance_4_5_1_70.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_5_1_71.json
+++ b/testdata/instances/instance_4_5_1_71.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_4_5_1_72.json
+++ b/testdata/instances/instance_4_5_1_72.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_5_1_73.json
+++ b/testdata/instances/instance_4_5_1_73.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_5_1_74.json
+++ b/testdata/instances/instance_4_5_1_74.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1000_30.json
+++ b/testdata/instances/instance_4_6_1000_30.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1000_31.json
+++ b/testdata/instances/instance_4_6_1000_31.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_4_6_1000_72.json
+++ b/testdata/instances/instance_4_6_1000_72.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_6_1000_73.json
+++ b/testdata/instances/instance_4_6_1000_73.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_6_1000_74.json
+++ b/testdata/instances/instance_4_6_1000_74.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1000_75.json
+++ b/testdata/instances/instance_4_6_1000_75.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1000_76.json
+++ b/testdata/instances/instance_4_6_1000_76.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_6_1000_77.json
+++ b/testdata/instances/instance_4_6_1000_77.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1000_78.json
+++ b/testdata/instances/instance_4_6_1000_78.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1000_79.json
+++ b/testdata/instances/instance_4_6_1000_79.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1_30.json
+++ b/testdata/instances/instance_4_6_1_30.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1_31.json
+++ b/testdata/instances/instance_4_6_1_31.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_4_6_1_72.json
+++ b/testdata/instances/instance_4_6_1_72.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_6_1_73.json
+++ b/testdata/instances/instance_4_6_1_73.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_6_1_74.json
+++ b/testdata/instances/instance_4_6_1_74.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1_75.json
+++ b/testdata/instances/instance_4_6_1_75.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1_76.json
+++ b/testdata/instances/instance_4_6_1_76.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_6_1_77.json
+++ b/testdata/instances/instance_4_6_1_77.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1_78.json
+++ b/testdata/instances/instance_4_6_1_78.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_6_1_79.json
+++ b/testdata/instances/instance_4_6_1_79.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_7_1000_32.json
+++ b/testdata/instances/instance_4_7_1000_32.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_7_1000_33.json
+++ b/testdata/instances/instance_4_7_1000_33.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_7_1000_77.json
+++ b/testdata/instances/instance_4_7_1000_77.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_7_1000_78.json
+++ b/testdata/instances/instance_4_7_1000_78.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_7_1000_79.json
+++ b/testdata/instances/instance_4_7_1000_79.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_7_1000_80.json
+++ b/testdata/instances/instance_4_7_1000_80.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_7_1000_81.json
+++ b/testdata/instances/instance_4_7_1000_81.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_7_1000_82.json
+++ b/testdata/instances/instance_4_7_1000_82.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_7_1000_83.json
+++ b/testdata/instances/instance_4_7_1000_83.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_7_1000_84.json
+++ b/testdata/instances/instance_4_7_1000_84.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_7_1_32.json
+++ b/testdata/instances/instance_4_7_1_32.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_7_1_33.json
+++ b/testdata/instances/instance_4_7_1_33.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_7_1_77.json
+++ b/testdata/instances/instance_4_7_1_77.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_7_1_78.json
+++ b/testdata/instances/instance_4_7_1_78.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_7_1_79.json
+++ b/testdata/instances/instance_4_7_1_79.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_7_1_80.json
+++ b/testdata/instances/instance_4_7_1_80.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_7_1_81.json
+++ b/testdata/instances/instance_4_7_1_81.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_7_1_82.json
+++ b/testdata/instances/instance_4_7_1_82.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_7_1_83.json
+++ b/testdata/instances/instance_4_7_1_83.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_7_1_84.json
+++ b/testdata/instances/instance_4_7_1_84.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_8_1000_34.json
+++ b/testdata/instances/instance_4_8_1000_34.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_4_8_1000_35.json
+++ b/testdata/instances/instance_4_8_1000_35.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_8_1000_82.json
+++ b/testdata/instances/instance_4_8_1000_82.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_8_1000_83.json
+++ b/testdata/instances/instance_4_8_1000_83.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_8_1000_84.json
+++ b/testdata/instances/instance_4_8_1000_84.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_8_1000_85.json
+++ b/testdata/instances/instance_4_8_1000_85.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_8_1000_86.json
+++ b/testdata/instances/instance_4_8_1000_86.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_8_1000_87.json
+++ b/testdata/instances/instance_4_8_1000_87.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_8_1000_88.json
+++ b/testdata/instances/instance_4_8_1000_88.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_8_1000_89.json
+++ b/testdata/instances/instance_4_8_1000_89.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_8_1_34.json
+++ b/testdata/instances/instance_4_8_1_34.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_4_8_1_35.json
+++ b/testdata/instances/instance_4_8_1_35.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_8_1_82.json
+++ b/testdata/instances/instance_4_8_1_82.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_4_8_1_83.json
+++ b/testdata/instances/instance_4_8_1_83.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_8_1_84.json
+++ b/testdata/instances/instance_4_8_1_84.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_8_1_85.json
+++ b/testdata/instances/instance_4_8_1_85.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_8_1_86.json
+++ b/testdata/instances/instance_4_8_1_86.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_4_8_1_87.json
+++ b/testdata/instances/instance_4_8_1_87.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_8_1_88.json
+++ b/testdata/instances/instance_4_8_1_88.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_8_1_89.json
+++ b/testdata/instances/instance_4_8_1_89.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1000_36.json
+++ b/testdata/instances/instance_4_9_1000_36.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_9_1000_37.json
+++ b/testdata/instances/instance_4_9_1000_37.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1000_87.json
+++ b/testdata/instances/instance_4_9_1000_87.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1000_88.json
+++ b/testdata/instances/instance_4_9_1000_88.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_9_1000_89.json
+++ b/testdata/instances/instance_4_9_1000_89.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1000_90.json
+++ b/testdata/instances/instance_4_9_1000_90.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_9_1000_91.json
+++ b/testdata/instances/instance_4_9_1000_91.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_4_9_1000_92.json
+++ b/testdata/instances/instance_4_9_1000_92.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1000_93.json
+++ b/testdata/instances/instance_4_9_1000_93.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1000_94.json
+++ b/testdata/instances/instance_4_9_1000_94.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_9_1_36.json
+++ b/testdata/instances/instance_4_9_1_36.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_9_1_37.json
+++ b/testdata/instances/instance_4_9_1_37.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1_87.json
+++ b/testdata/instances/instance_4_9_1_87.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1_88.json
+++ b/testdata/instances/instance_4_9_1_88.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_4_9_1_89.json
+++ b/testdata/instances/instance_4_9_1_89.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1_90.json
+++ b/testdata/instances/instance_4_9_1_90.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_4_9_1_91.json
+++ b/testdata/instances/instance_4_9_1_91.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_4_9_1_92.json
+++ b/testdata/instances/instance_4_9_1_92.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1_93.json
+++ b/testdata/instances/instance_4_9_1_93.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_4_9_1_94.json
+++ b/testdata/instances/instance_4_9_1_94.json
@@ -1,5 +1,5 @@
 {
-  "M": 4,
+  "ElementCount": 4,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_10_1000_152.json
+++ b/testdata/instances/instance_5_10_1000_152.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_10_1000_153.json
+++ b/testdata/instances/instance_5_10_1000_153.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_10_1000_154.json
+++ b/testdata/instances/instance_5_10_1000_154.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_10_1000_155.json
+++ b/testdata/instances/instance_5_10_1000_155.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_10_1000_156.json
+++ b/testdata/instances/instance_5_10_1000_156.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_10_1000_157.json
+++ b/testdata/instances/instance_5_10_1000_157.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_10_1000_158.json
+++ b/testdata/instances/instance_5_10_1000_158.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_10_1000_159.json
+++ b/testdata/instances/instance_5_10_1000_159.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_10_1_152.json
+++ b/testdata/instances/instance_5_10_1_152.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_10_1_153.json
+++ b/testdata/instances/instance_5_10_1_153.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_10_1_154.json
+++ b/testdata/instances/instance_5_10_1_154.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_10_1_155.json
+++ b/testdata/instances/instance_5_10_1_155.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_10_1_156.json
+++ b/testdata/instances/instance_5_10_1_156.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_10_1_157.json
+++ b/testdata/instances/instance_5_10_1_157.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_10_1_158.json
+++ b/testdata/instances/instance_5_10_1_158.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_10_1_159.json
+++ b/testdata/instances/instance_5_10_1_159.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1000_157.json
+++ b/testdata/instances/instance_5_11_1000_157.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1000_158.json
+++ b/testdata/instances/instance_5_11_1000_158.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_11_1000_159.json
+++ b/testdata/instances/instance_5_11_1000_159.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1000_160.json
+++ b/testdata/instances/instance_5_11_1000_160.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1000_161.json
+++ b/testdata/instances/instance_5_11_1000_161.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1000_162.json
+++ b/testdata/instances/instance_5_11_1000_162.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_11_1000_163.json
+++ b/testdata/instances/instance_5_11_1000_163.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1000_164.json
+++ b/testdata/instances/instance_5_11_1000_164.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1_157.json
+++ b/testdata/instances/instance_5_11_1_157.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1_158.json
+++ b/testdata/instances/instance_5_11_1_158.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_11_1_159.json
+++ b/testdata/instances/instance_5_11_1_159.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1_160.json
+++ b/testdata/instances/instance_5_11_1_160.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1_161.json
+++ b/testdata/instances/instance_5_11_1_161.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1_162.json
+++ b/testdata/instances/instance_5_11_1_162.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_11_1_163.json
+++ b/testdata/instances/instance_5_11_1_163.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_11_1_164.json
+++ b/testdata/instances/instance_5_11_1_164.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_12_1000_162.json
+++ b/testdata/instances/instance_5_12_1000_162.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_12_1000_163.json
+++ b/testdata/instances/instance_5_12_1000_163.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_12_1000_164.json
+++ b/testdata/instances/instance_5_12_1000_164.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_12_1000_165.json
+++ b/testdata/instances/instance_5_12_1000_165.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_12_1000_166.json
+++ b/testdata/instances/instance_5_12_1000_166.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_12_1000_167.json
+++ b/testdata/instances/instance_5_12_1000_167.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_12_1000_168.json
+++ b/testdata/instances/instance_5_12_1000_168.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_12_1000_169.json
+++ b/testdata/instances/instance_5_12_1000_169.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_12_1_162.json
+++ b/testdata/instances/instance_5_12_1_162.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_12_1_163.json
+++ b/testdata/instances/instance_5_12_1_163.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_12_1_164.json
+++ b/testdata/instances/instance_5_12_1_164.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_12_1_165.json
+++ b/testdata/instances/instance_5_12_1_165.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_12_1_166.json
+++ b/testdata/instances/instance_5_12_1_166.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_12_1_167.json
+++ b/testdata/instances/instance_5_12_1_167.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_12_1_168.json
+++ b/testdata/instances/instance_5_12_1_168.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_12_1_169.json
+++ b/testdata/instances/instance_5_12_1_169.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_13_1000_167.json
+++ b/testdata/instances/instance_5_13_1000_167.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_13_1000_168.json
+++ b/testdata/instances/instance_5_13_1000_168.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_13_1000_169.json
+++ b/testdata/instances/instance_5_13_1000_169.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_13_1000_170.json
+++ b/testdata/instances/instance_5_13_1000_170.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_13_1000_171.json
+++ b/testdata/instances/instance_5_13_1000_171.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_13_1000_172.json
+++ b/testdata/instances/instance_5_13_1000_172.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_13_1000_173.json
+++ b/testdata/instances/instance_5_13_1000_173.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_13_1000_174.json
+++ b/testdata/instances/instance_5_13_1000_174.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_13_1_167.json
+++ b/testdata/instances/instance_5_13_1_167.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_13_1_168.json
+++ b/testdata/instances/instance_5_13_1_168.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_13_1_169.json
+++ b/testdata/instances/instance_5_13_1_169.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_13_1_170.json
+++ b/testdata/instances/instance_5_13_1_170.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_13_1_171.json
+++ b/testdata/instances/instance_5_13_1_171.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_13_1_172.json
+++ b/testdata/instances/instance_5_13_1_172.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_13_1_173.json
+++ b/testdata/instances/instance_5_13_1_173.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_13_1_174.json
+++ b/testdata/instances/instance_5_13_1_174.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_14_1000_172.json
+++ b/testdata/instances/instance_5_14_1000_172.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1000_173.json
+++ b/testdata/instances/instance_5_14_1000_173.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1000_174.json
+++ b/testdata/instances/instance_5_14_1000_174.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_14_1000_175.json
+++ b/testdata/instances/instance_5_14_1000_175.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1000_176.json
+++ b/testdata/instances/instance_5_14_1000_176.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1000_177.json
+++ b/testdata/instances/instance_5_14_1000_177.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_14_1000_178.json
+++ b/testdata/instances/instance_5_14_1000_178.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1000_179.json
+++ b/testdata/instances/instance_5_14_1000_179.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1_172.json
+++ b/testdata/instances/instance_5_14_1_172.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1_173.json
+++ b/testdata/instances/instance_5_14_1_173.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1_174.json
+++ b/testdata/instances/instance_5_14_1_174.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_14_1_175.json
+++ b/testdata/instances/instance_5_14_1_175.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1_176.json
+++ b/testdata/instances/instance_5_14_1_176.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1_177.json
+++ b/testdata/instances/instance_5_14_1_177.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_14_1_178.json
+++ b/testdata/instances/instance_5_14_1_178.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_14_1_179.json
+++ b/testdata/instances/instance_5_14_1_179.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_15_1000_177.json
+++ b/testdata/instances/instance_5_15_1000_177.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_15_1000_178.json
+++ b/testdata/instances/instance_5_15_1000_178.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_15_1000_179.json
+++ b/testdata/instances/instance_5_15_1000_179.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_15_1000_180.json
+++ b/testdata/instances/instance_5_15_1000_180.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_15_1000_181.json
+++ b/testdata/instances/instance_5_15_1000_181.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_15_1000_182.json
+++ b/testdata/instances/instance_5_15_1000_182.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_15_1000_183.json
+++ b/testdata/instances/instance_5_15_1000_183.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_15_1000_184.json
+++ b/testdata/instances/instance_5_15_1000_184.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_15_1_177.json
+++ b/testdata/instances/instance_5_15_1_177.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_15_1_178.json
+++ b/testdata/instances/instance_5_15_1_178.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_15_1_179.json
+++ b/testdata/instances/instance_5_15_1_179.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_15_1_180.json
+++ b/testdata/instances/instance_5_15_1_180.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_15_1_181.json
+++ b/testdata/instances/instance_5_15_1_181.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_15_1_182.json
+++ b/testdata/instances/instance_5_15_1_182.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_15_1_183.json
+++ b/testdata/instances/instance_5_15_1_183.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_15_1_184.json
+++ b/testdata/instances/instance_5_15_1_184.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_16_1000_182.json
+++ b/testdata/instances/instance_5_16_1000_182.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_16_1000_183.json
+++ b/testdata/instances/instance_5_16_1000_183.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_16_1000_184.json
+++ b/testdata/instances/instance_5_16_1000_184.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_16_1000_185.json
+++ b/testdata/instances/instance_5_16_1000_185.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_16_1000_186.json
+++ b/testdata/instances/instance_5_16_1000_186.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_16_1000_187.json
+++ b/testdata/instances/instance_5_16_1000_187.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_16_1000_188.json
+++ b/testdata/instances/instance_5_16_1000_188.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_16_1000_189.json
+++ b/testdata/instances/instance_5_16_1000_189.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_16_1_182.json
+++ b/testdata/instances/instance_5_16_1_182.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_16_1_183.json
+++ b/testdata/instances/instance_5_16_1_183.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_16_1_184.json
+++ b/testdata/instances/instance_5_16_1_184.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_16_1_185.json
+++ b/testdata/instances/instance_5_16_1_185.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_16_1_186.json
+++ b/testdata/instances/instance_5_16_1_186.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_16_1_187.json
+++ b/testdata/instances/instance_5_16_1_187.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_16_1_188.json
+++ b/testdata/instances/instance_5_16_1_188.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_16_1_189.json
+++ b/testdata/instances/instance_5_16_1_189.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1000_187.json
+++ b/testdata/instances/instance_5_17_1000_187.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_17_1000_188.json
+++ b/testdata/instances/instance_5_17_1000_188.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1000_189.json
+++ b/testdata/instances/instance_5_17_1000_189.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1000_190.json
+++ b/testdata/instances/instance_5_17_1000_190.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1000_191.json
+++ b/testdata/instances/instance_5_17_1000_191.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1000_192.json
+++ b/testdata/instances/instance_5_17_1000_192.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_17_1000_193.json
+++ b/testdata/instances/instance_5_17_1000_193.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1000_194.json
+++ b/testdata/instances/instance_5_17_1000_194.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_17_1_187.json
+++ b/testdata/instances/instance_5_17_1_187.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_17_1_188.json
+++ b/testdata/instances/instance_5_17_1_188.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1_189.json
+++ b/testdata/instances/instance_5_17_1_189.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1_190.json
+++ b/testdata/instances/instance_5_17_1_190.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1_191.json
+++ b/testdata/instances/instance_5_17_1_191.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1_192.json
+++ b/testdata/instances/instance_5_17_1_192.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_17_1_193.json
+++ b/testdata/instances/instance_5_17_1_193.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_17_1_194.json
+++ b/testdata/instances/instance_5_17_1_194.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_18_1000_192.json
+++ b/testdata/instances/instance_5_18_1000_192.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_18_1000_193.json
+++ b/testdata/instances/instance_5_18_1000_193.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_18_1000_194.json
+++ b/testdata/instances/instance_5_18_1000_194.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_18_1000_195.json
+++ b/testdata/instances/instance_5_18_1000_195.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_18_1000_196.json
+++ b/testdata/instances/instance_5_18_1000_196.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_18_1000_197.json
+++ b/testdata/instances/instance_5_18_1000_197.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_18_1000_198.json
+++ b/testdata/instances/instance_5_18_1000_198.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_18_1000_199.json
+++ b/testdata/instances/instance_5_18_1000_199.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_18_1_192.json
+++ b/testdata/instances/instance_5_18_1_192.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_18_1_193.json
+++ b/testdata/instances/instance_5_18_1_193.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_18_1_194.json
+++ b/testdata/instances/instance_5_18_1_194.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_18_1_195.json
+++ b/testdata/instances/instance_5_18_1_195.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_18_1_196.json
+++ b/testdata/instances/instance_5_18_1_196.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_18_1_197.json
+++ b/testdata/instances/instance_5_18_1_197.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_18_1_198.json
+++ b/testdata/instances/instance_5_18_1_198.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_18_1_199.json
+++ b/testdata/instances/instance_5_18_1_199.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_19_1000_197.json
+++ b/testdata/instances/instance_5_19_1000_197.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1000_198.json
+++ b/testdata/instances/instance_5_19_1000_198.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1000_199.json
+++ b/testdata/instances/instance_5_19_1000_199.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_19_1000_200.json
+++ b/testdata/instances/instance_5_19_1000_200.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1000_201.json
+++ b/testdata/instances/instance_5_19_1000_201.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_19_1000_202.json
+++ b/testdata/instances/instance_5_19_1000_202.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1000_203.json
+++ b/testdata/instances/instance_5_19_1000_203.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1000_204.json
+++ b/testdata/instances/instance_5_19_1000_204.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1_197.json
+++ b/testdata/instances/instance_5_19_1_197.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1_198.json
+++ b/testdata/instances/instance_5_19_1_198.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1_199.json
+++ b/testdata/instances/instance_5_19_1_199.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_19_1_200.json
+++ b/testdata/instances/instance_5_19_1_200.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1_201.json
+++ b/testdata/instances/instance_5_19_1_201.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_19_1_202.json
+++ b/testdata/instances/instance_5_19_1_202.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1_203.json
+++ b/testdata/instances/instance_5_19_1_203.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_19_1_204.json
+++ b/testdata/instances/instance_5_19_1_204.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1000_107.json
+++ b/testdata/instances/instance_5_1_1000_107.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1000_108.json
+++ b/testdata/instances/instance_5_1_1000_108.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3,

--- a/testdata/instances/instance_5_1_1000_109.json
+++ b/testdata/instances/instance_5_1_1000_109.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1000_110.json
+++ b/testdata/instances/instance_5_1_1000_110.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1000_111.json
+++ b/testdata/instances/instance_5_1_1000_111.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1000_112.json
+++ b/testdata/instances/instance_5_1_1000_112.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1000_113.json
+++ b/testdata/instances/instance_5_1_1000_113.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_1_1000_114.json
+++ b/testdata/instances/instance_5_1_1000_114.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1_107.json
+++ b/testdata/instances/instance_5_1_1_107.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1_108.json
+++ b/testdata/instances/instance_5_1_1_108.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3,

--- a/testdata/instances/instance_5_1_1_109.json
+++ b/testdata/instances/instance_5_1_1_109.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1_110.json
+++ b/testdata/instances/instance_5_1_1_110.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1_111.json
+++ b/testdata/instances/instance_5_1_1_111.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1_112.json
+++ b/testdata/instances/instance_5_1_1_112.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_1_1_113.json
+++ b/testdata/instances/instance_5_1_1_113.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_1_1_114.json
+++ b/testdata/instances/instance_5_1_1_114.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1000_202.json
+++ b/testdata/instances/instance_5_20_1000_202.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1000_203.json
+++ b/testdata/instances/instance_5_20_1000_203.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1000_204.json
+++ b/testdata/instances/instance_5_20_1000_204.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1000_205.json
+++ b/testdata/instances/instance_5_20_1000_205.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_20_1000_206.json
+++ b/testdata/instances/instance_5_20_1000_206.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_20_1000_207.json
+++ b/testdata/instances/instance_5_20_1000_207.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1000_208.json
+++ b/testdata/instances/instance_5_20_1000_208.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1000_209.json
+++ b/testdata/instances/instance_5_20_1000_209.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_20_1_202.json
+++ b/testdata/instances/instance_5_20_1_202.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1_203.json
+++ b/testdata/instances/instance_5_20_1_203.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1_204.json
+++ b/testdata/instances/instance_5_20_1_204.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1_205.json
+++ b/testdata/instances/instance_5_20_1_205.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_20_1_206.json
+++ b/testdata/instances/instance_5_20_1_206.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_20_1_207.json
+++ b/testdata/instances/instance_5_20_1_207.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1_208.json
+++ b/testdata/instances/instance_5_20_1_208.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_20_1_209.json
+++ b/testdata/instances/instance_5_20_1_209.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_21_1000_207.json
+++ b/testdata/instances/instance_5_21_1000_207.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_21_1000_208.json
+++ b/testdata/instances/instance_5_21_1000_208.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_21_1000_209.json
+++ b/testdata/instances/instance_5_21_1000_209.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_21_1000_210.json
+++ b/testdata/instances/instance_5_21_1000_210.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_21_1000_211.json
+++ b/testdata/instances/instance_5_21_1000_211.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_21_1000_212.json
+++ b/testdata/instances/instance_5_21_1000_212.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_21_1000_213.json
+++ b/testdata/instances/instance_5_21_1000_213.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_21_1000_214.json
+++ b/testdata/instances/instance_5_21_1000_214.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_21_1_207.json
+++ b/testdata/instances/instance_5_21_1_207.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_21_1_208.json
+++ b/testdata/instances/instance_5_21_1_208.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_21_1_209.json
+++ b/testdata/instances/instance_5_21_1_209.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_21_1_210.json
+++ b/testdata/instances/instance_5_21_1_210.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_21_1_211.json
+++ b/testdata/instances/instance_5_21_1_211.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_21_1_212.json
+++ b/testdata/instances/instance_5_21_1_212.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_21_1_213.json
+++ b/testdata/instances/instance_5_21_1_213.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_21_1_214.json
+++ b/testdata/instances/instance_5_21_1_214.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_22_1000_212.json
+++ b/testdata/instances/instance_5_22_1000_212.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_22_1000_213.json
+++ b/testdata/instances/instance_5_22_1000_213.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_22_1000_214.json
+++ b/testdata/instances/instance_5_22_1000_214.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_22_1000_215.json
+++ b/testdata/instances/instance_5_22_1000_215.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_22_1000_216.json
+++ b/testdata/instances/instance_5_22_1000_216.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_22_1000_217.json
+++ b/testdata/instances/instance_5_22_1000_217.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_22_1000_218.json
+++ b/testdata/instances/instance_5_22_1000_218.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_22_1000_219.json
+++ b/testdata/instances/instance_5_22_1000_219.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_22_1_212.json
+++ b/testdata/instances/instance_5_22_1_212.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_22_1_213.json
+++ b/testdata/instances/instance_5_22_1_213.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_22_1_214.json
+++ b/testdata/instances/instance_5_22_1_214.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_22_1_215.json
+++ b/testdata/instances/instance_5_22_1_215.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_22_1_216.json
+++ b/testdata/instances/instance_5_22_1_216.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_22_1_217.json
+++ b/testdata/instances/instance_5_22_1_217.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_22_1_218.json
+++ b/testdata/instances/instance_5_22_1_218.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_22_1_219.json
+++ b/testdata/instances/instance_5_22_1_219.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_23_1000_217.json
+++ b/testdata/instances/instance_5_23_1000_217.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_23_1000_218.json
+++ b/testdata/instances/instance_5_23_1000_218.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_23_1000_219.json
+++ b/testdata/instances/instance_5_23_1000_219.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_23_1000_220.json
+++ b/testdata/instances/instance_5_23_1000_220.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_23_1000_221.json
+++ b/testdata/instances/instance_5_23_1000_221.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_23_1000_222.json
+++ b/testdata/instances/instance_5_23_1000_222.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_23_1000_223.json
+++ b/testdata/instances/instance_5_23_1000_223.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_23_1000_224.json
+++ b/testdata/instances/instance_5_23_1000_224.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_23_1_217.json
+++ b/testdata/instances/instance_5_23_1_217.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_23_1_218.json
+++ b/testdata/instances/instance_5_23_1_218.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_23_1_219.json
+++ b/testdata/instances/instance_5_23_1_219.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_23_1_220.json
+++ b/testdata/instances/instance_5_23_1_220.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_23_1_221.json
+++ b/testdata/instances/instance_5_23_1_221.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_23_1_222.json
+++ b/testdata/instances/instance_5_23_1_222.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_23_1_223.json
+++ b/testdata/instances/instance_5_23_1_223.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_23_1_224.json
+++ b/testdata/instances/instance_5_23_1_224.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_24_1000_222.json
+++ b/testdata/instances/instance_5_24_1000_222.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_24_1000_223.json
+++ b/testdata/instances/instance_5_24_1000_223.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_24_1000_224.json
+++ b/testdata/instances/instance_5_24_1000_224.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_24_1000_225.json
+++ b/testdata/instances/instance_5_24_1000_225.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_24_1000_226.json
+++ b/testdata/instances/instance_5_24_1000_226.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_24_1000_227.json
+++ b/testdata/instances/instance_5_24_1000_227.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_24_1000_228.json
+++ b/testdata/instances/instance_5_24_1000_228.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_24_1000_229.json
+++ b/testdata/instances/instance_5_24_1000_229.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_24_1_222.json
+++ b/testdata/instances/instance_5_24_1_222.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_24_1_223.json
+++ b/testdata/instances/instance_5_24_1_223.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_24_1_224.json
+++ b/testdata/instances/instance_5_24_1_224.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_24_1_225.json
+++ b/testdata/instances/instance_5_24_1_225.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_24_1_226.json
+++ b/testdata/instances/instance_5_24_1_226.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_24_1_227.json
+++ b/testdata/instances/instance_5_24_1_227.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_24_1_228.json
+++ b/testdata/instances/instance_5_24_1_228.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_24_1_229.json
+++ b/testdata/instances/instance_5_24_1_229.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_25_1000_0.json
+++ b/testdata/instances/instance_5_25_1000_0.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_25_1000_1.json
+++ b/testdata/instances/instance_5_25_1000_1.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_2_1000_112.json
+++ b/testdata/instances/instance_5_2_1000_112.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_2_1000_113.json
+++ b/testdata/instances/instance_5_2_1000_113.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_2_1000_114.json
+++ b/testdata/instances/instance_5_2_1000_114.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_2_1000_115.json
+++ b/testdata/instances/instance_5_2_1000_115.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_2_1000_116.json
+++ b/testdata/instances/instance_5_2_1000_116.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_2_1000_117.json
+++ b/testdata/instances/instance_5_2_1000_117.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_2_1000_118.json
+++ b/testdata/instances/instance_5_2_1000_118.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_2_1000_119.json
+++ b/testdata/instances/instance_5_2_1000_119.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_2_1_112.json
+++ b/testdata/instances/instance_5_2_1_112.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_2_1_113.json
+++ b/testdata/instances/instance_5_2_1_113.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_2_1_114.json
+++ b/testdata/instances/instance_5_2_1_114.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_2_1_115.json
+++ b/testdata/instances/instance_5_2_1_115.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_2_1_116.json
+++ b/testdata/instances/instance_5_2_1_116.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_2_1_117.json
+++ b/testdata/instances/instance_5_2_1_117.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_2_1_118.json
+++ b/testdata/instances/instance_5_2_1_118.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_2_1_119.json
+++ b/testdata/instances/instance_5_2_1_119.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1000_117.json
+++ b/testdata/instances/instance_5_3_1000_117.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1000_118.json
+++ b/testdata/instances/instance_5_3_1000_118.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_3_1000_119.json
+++ b/testdata/instances/instance_5_3_1000_119.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1000_120.json
+++ b/testdata/instances/instance_5_3_1000_120.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1000_121.json
+++ b/testdata/instances/instance_5_3_1000_121.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1000_122.json
+++ b/testdata/instances/instance_5_3_1000_122.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_3_1000_123.json
+++ b/testdata/instances/instance_5_3_1000_123.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1000_124.json
+++ b/testdata/instances/instance_5_3_1000_124.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_3_1_117.json
+++ b/testdata/instances/instance_5_3_1_117.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1_118.json
+++ b/testdata/instances/instance_5_3_1_118.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2

--- a/testdata/instances/instance_5_3_1_119.json
+++ b/testdata/instances/instance_5_3_1_119.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1_120.json
+++ b/testdata/instances/instance_5_3_1_120.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1_121.json
+++ b/testdata/instances/instance_5_3_1_121.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1_122.json
+++ b/testdata/instances/instance_5_3_1_122.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_3_1_123.json
+++ b/testdata/instances/instance_5_3_1_123.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_3_1_124.json
+++ b/testdata/instances/instance_5_3_1_124.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_4_1000_122.json
+++ b/testdata/instances/instance_5_4_1000_122.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_4_1000_123.json
+++ b/testdata/instances/instance_5_4_1000_123.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_4_1000_124.json
+++ b/testdata/instances/instance_5_4_1000_124.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_4_1000_125.json
+++ b/testdata/instances/instance_5_4_1000_125.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_4_1000_126.json
+++ b/testdata/instances/instance_5_4_1000_126.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_4_1000_127.json
+++ b/testdata/instances/instance_5_4_1000_127.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_4_1000_128.json
+++ b/testdata/instances/instance_5_4_1000_128.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_4_1000_129.json
+++ b/testdata/instances/instance_5_4_1000_129.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_4_1_122.json
+++ b/testdata/instances/instance_5_4_1_122.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_4_1_123.json
+++ b/testdata/instances/instance_5_4_1_123.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_4_1_124.json
+++ b/testdata/instances/instance_5_4_1_124.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_4_1_125.json
+++ b/testdata/instances/instance_5_4_1_125.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_4_1_126.json
+++ b/testdata/instances/instance_5_4_1_126.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       3

--- a/testdata/instances/instance_5_4_1_127.json
+++ b/testdata/instances/instance_5_4_1_127.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_4_1_128.json
+++ b/testdata/instances/instance_5_4_1_128.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_4_1_129.json
+++ b/testdata/instances/instance_5_4_1_129.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_5_1000_127.json
+++ b/testdata/instances/instance_5_5_1000_127.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_5_1000_128.json
+++ b/testdata/instances/instance_5_5_1000_128.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_5_1000_129.json
+++ b/testdata/instances/instance_5_5_1000_129.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_5_1000_130.json
+++ b/testdata/instances/instance_5_5_1000_130.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_5_1000_131.json
+++ b/testdata/instances/instance_5_5_1000_131.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_5_1000_132.json
+++ b/testdata/instances/instance_5_5_1000_132.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_5_1000_133.json
+++ b/testdata/instances/instance_5_5_1000_133.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_5_1000_134.json
+++ b/testdata/instances/instance_5_5_1000_134.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_5_1_127.json
+++ b/testdata/instances/instance_5_5_1_127.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_5_1_128.json
+++ b/testdata/instances/instance_5_5_1_128.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_5_1_129.json
+++ b/testdata/instances/instance_5_5_1_129.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_5_1_130.json
+++ b/testdata/instances/instance_5_5_1_130.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_5_1_131.json
+++ b/testdata/instances/instance_5_5_1_131.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_5_1_132.json
+++ b/testdata/instances/instance_5_5_1_132.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_5_1_133.json
+++ b/testdata/instances/instance_5_5_1_133.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_5_1_134.json
+++ b/testdata/instances/instance_5_5_1_134.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1000_132.json
+++ b/testdata/instances/instance_5_6_1000_132.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1000_133.json
+++ b/testdata/instances/instance_5_6_1000_133.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_6_1000_134.json
+++ b/testdata/instances/instance_5_6_1000_134.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1000_135.json
+++ b/testdata/instances/instance_5_6_1000_135.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1000_136.json
+++ b/testdata/instances/instance_5_6_1000_136.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1000_137.json
+++ b/testdata/instances/instance_5_6_1000_137.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1000_138.json
+++ b/testdata/instances/instance_5_6_1000_138.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_6_1000_139.json
+++ b/testdata/instances/instance_5_6_1000_139.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_6_1_132.json
+++ b/testdata/instances/instance_5_6_1_132.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1_133.json
+++ b/testdata/instances/instance_5_6_1_133.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_6_1_134.json
+++ b/testdata/instances/instance_5_6_1_134.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1_135.json
+++ b/testdata/instances/instance_5_6_1_135.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1_136.json
+++ b/testdata/instances/instance_5_6_1_136.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1_137.json
+++ b/testdata/instances/instance_5_6_1_137.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_6_1_138.json
+++ b/testdata/instances/instance_5_6_1_138.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_6_1_139.json
+++ b/testdata/instances/instance_5_6_1_139.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_7_1000_137.json
+++ b/testdata/instances/instance_5_7_1000_137.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_7_1000_138.json
+++ b/testdata/instances/instance_5_7_1000_138.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_7_1000_139.json
+++ b/testdata/instances/instance_5_7_1000_139.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_7_1000_140.json
+++ b/testdata/instances/instance_5_7_1000_140.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_7_1000_141.json
+++ b/testdata/instances/instance_5_7_1000_141.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_7_1000_142.json
+++ b/testdata/instances/instance_5_7_1000_142.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_7_1000_143.json
+++ b/testdata/instances/instance_5_7_1000_143.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_7_1000_144.json
+++ b/testdata/instances/instance_5_7_1000_144.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_7_1_137.json
+++ b/testdata/instances/instance_5_7_1_137.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_7_1_138.json
+++ b/testdata/instances/instance_5_7_1_138.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       2,

--- a/testdata/instances/instance_5_7_1_139.json
+++ b/testdata/instances/instance_5_7_1_139.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_7_1_140.json
+++ b/testdata/instances/instance_5_7_1_140.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_7_1_141.json
+++ b/testdata/instances/instance_5_7_1_141.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_7_1_142.json
+++ b/testdata/instances/instance_5_7_1_142.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_7_1_143.json
+++ b/testdata/instances/instance_5_7_1_143.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_7_1_144.json
+++ b/testdata/instances/instance_5_7_1_144.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_8_1000_142.json
+++ b/testdata/instances/instance_5_8_1000_142.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_8_1000_143.json
+++ b/testdata/instances/instance_5_8_1000_143.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_8_1000_144.json
+++ b/testdata/instances/instance_5_8_1000_144.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_8_1000_145.json
+++ b/testdata/instances/instance_5_8_1000_145.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_8_1000_146.json
+++ b/testdata/instances/instance_5_8_1000_146.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_8_1000_147.json
+++ b/testdata/instances/instance_5_8_1000_147.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_8_1000_148.json
+++ b/testdata/instances/instance_5_8_1000_148.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_8_1000_149.json
+++ b/testdata/instances/instance_5_8_1000_149.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_8_1_142.json
+++ b/testdata/instances/instance_5_8_1_142.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_8_1_143.json
+++ b/testdata/instances/instance_5_8_1_143.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_8_1_144.json
+++ b/testdata/instances/instance_5_8_1_144.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_8_1_145.json
+++ b/testdata/instances/instance_5_8_1_145.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_8_1_146.json
+++ b/testdata/instances/instance_5_8_1_146.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_8_1_147.json
+++ b/testdata/instances/instance_5_8_1_147.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_8_1_148.json
+++ b/testdata/instances/instance_5_8_1_148.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_8_1_149.json
+++ b/testdata/instances/instance_5_8_1_149.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_9_1000_147.json
+++ b/testdata/instances/instance_5_9_1000_147.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_9_1000_148.json
+++ b/testdata/instances/instance_5_9_1000_148.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_9_1000_149.json
+++ b/testdata/instances/instance_5_9_1000_149.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_9_1000_150.json
+++ b/testdata/instances/instance_5_9_1000_150.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_9_1000_151.json
+++ b/testdata/instances/instance_5_9_1000_151.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_9_1000_152.json
+++ b/testdata/instances/instance_5_9_1000_152.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_9_1000_153.json
+++ b/testdata/instances/instance_5_9_1000_153.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_9_1000_154.json
+++ b/testdata/instances/instance_5_9_1000_154.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_9_1_147.json
+++ b/testdata/instances/instance_5_9_1_147.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1

--- a/testdata/instances/instance_5_9_1_148.json
+++ b/testdata/instances/instance_5_9_1_148.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_9_1_149.json
+++ b/testdata/instances/instance_5_9_1_149.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_9_1_150.json
+++ b/testdata/instances/instance_5_9_1_150.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0

--- a/testdata/instances/instance_5_9_1_151.json
+++ b/testdata/instances/instance_5_9_1_151.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       1,

--- a/testdata/instances/instance_5_9_1_152.json
+++ b/testdata/instances/instance_5_9_1_152.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       4

--- a/testdata/instances/instance_5_9_1_153.json
+++ b/testdata/instances/instance_5_9_1_153.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,

--- a/testdata/instances/instance_5_9_1_154.json
+++ b/testdata/instances/instance_5_9_1_154.json
@@ -1,5 +1,5 @@
 {
-  "M": 5,
+  "ElementCount": 5,
   "Subsets": [
     [
       0,


### PR DESCRIPTION
This is to prefer more descriptive names in the exported structs and fields.

Also the use of the `ElementCount` is commented in the `README.md` code example.