### PR TITLE
ci: stop install Python tool requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Python dependencies for tools
-        run: pip install -r ./tools/requirements.txt
-
       - name: Set up Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
These are no longer needed by CI, in particular the tests run.