### PR TITLE
chore: remove gonum dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/snow-abstraction/cover
 
 go 1.23
 
-require (
-	gonum.org/v1/gonum v0.15.1
-	gotest.tools/v3 v3.5.1
-)
+require gotest.tools/v3 v3.5.1
 
 require github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-gonum.org/v1/gonum v0.15.1 h1:FNy7N6OUZVUaWG9pTiD+jlhdQ3lMP+/LcTpJ6+a8sQ0=
-gonum.org/v1/gonum v0.15.1/go.mod h1:eZTZuRFrzu5pcyjN5wJhcIhnUdNijYxX1T2IcrOGY0o=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
 gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=

--- a/internal/solvers/brute_test.go
+++ b/internal/solvers/brute_test.go
@@ -126,3 +126,46 @@ func BenchmarkBruteOnRandomTinyInstances(b *testing.B) {
 		}
 	}
 }
+
+func TestComb5_3(t *testing.T) {
+	expected := [][]int{
+		{0, 1, 2},
+		{0, 1, 3},
+		{0, 1, 4},
+		{0, 2, 3},
+		{0, 2, 4},
+		{0, 3, 4},
+		{1, 2, 3},
+		{1, 2, 4},
+		{1, 3, 4},
+		{2, 3, 4}}
+
+	actual := make([][]int, 0, len(expected))
+	generator := newCombinationGenerator(5, 3)
+
+	for generator.Next() {
+		comb := make([]int, len(generator.combination))
+		copy(comb, generator.combination)
+		actual = append(actual, comb)
+	}
+	assert.DeepEqual(t, expected, actual)
+}
+
+func TestComb4_4(t *testing.T) {
+	expected := [][]int{{0, 1, 2, 3}}
+
+	actual := make([][]int, 0, len(expected))
+	generator := newCombinationGenerator(4, 4)
+
+	for generator.Next() {
+		comb := make([]int, len(generator.combination))
+		copy(comb, generator.combination)
+		actual = append(actual, comb)
+	}
+	assert.DeepEqual(t, expected, actual)
+}
+
+func TestComb0_0(t *testing.T) {
+	c := newCombinationGenerator(0, 0)
+	assert.Assert(t, !c.Next())
+}


### PR DESCRIPTION
This is make `cover` only depend on the Go Standard libray.

The package gonum was only used to generate combinations so it was easy to write my own replacement.