### PR TITLE
chore: fix package visibility around CombinationGenerator

### DIFF
--- a/internal/solvers/brute.go
+++ b/internal/solvers/brute.go
@@ -104,7 +104,7 @@ func SolveByBruteForceInternal(ins instance) (subsetsEval, error) {
 	bestSubsetsEval.SubsetsIndices = make([]int, 0, nSubsetsToTry)
 	for i := 1; i <= nSubsetsToTry; i++ {
 		combinations := newCombinationGenerator(len(ins.subsets), i)
-		for combinations.Next() {
+		for combinations.next() {
 			updateBestSolutionFromSubsets(ins, combinations.combination, subsetsScratch, coverCountsScratch, &bestSubsetsEval)
 		}
 	}
@@ -118,7 +118,7 @@ func SolveByBruteForceInternal(ins instance) (subsetsEval, error) {
 	return bestSubsetsEval, nil
 }
 
-type CombinationGenerator struct {
+type combinationGenerator struct {
 	n           int
 	k           int
 	combination []int
@@ -126,11 +126,11 @@ type CombinationGenerator struct {
 
 // Make a generator generating 0-indexed (n, k) combinations in lexicographical order starting with
 // 0, 1, ..., k-1 and ending with n - k, ..., n -1
-func newCombinationGenerator(n, k int) *CombinationGenerator {
-	return &CombinationGenerator{n, k, nil}
+func newCombinationGenerator(n, k int) *combinationGenerator {
+	return &combinationGenerator{n, k, nil}
 }
 
-func (c *CombinationGenerator) Next() bool {
+func (c *combinationGenerator) next() bool {
 	if c.combination == nil {
 		if c.n < 1 || c.k < 1 {
 			return false

--- a/internal/solvers/brute_test.go
+++ b/internal/solvers/brute_test.go
@@ -143,7 +143,7 @@ func TestComb5_3(t *testing.T) {
 	actual := make([][]int, 0, len(expected))
 	generator := newCombinationGenerator(5, 3)
 
-	for generator.Next() {
+	for generator.next() {
 		comb := make([]int, len(generator.combination))
 		copy(comb, generator.combination)
 		actual = append(actual, comb)
@@ -157,7 +157,7 @@ func TestComb4_4(t *testing.T) {
 	actual := make([][]int, 0, len(expected))
 	generator := newCombinationGenerator(4, 4)
 
-	for generator.Next() {
+	for generator.next() {
 		comb := make([]int, len(generator.combination))
 		copy(comb, generator.combination)
 		actual = append(actual, comb)
@@ -167,5 +167,5 @@ func TestComb4_4(t *testing.T) {
 
 func TestComb0_0(t *testing.T) {
 	c := newCombinationGenerator(0, 0)
-	assert.Assert(t, !c.Next())
+	assert.Assert(t, !c.next())
 }


### PR DESCRIPTION
These symbols should not be visible outside of the solvers package.