### PR TITLE
fix: use `ElementCount` not `M` in solve_sc.py

### DIFF
--- a/tools/solve_sc.py
+++ b/tools/solve_sc.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         for cost in instance["Costs"]
     ]
 
-    constraints = [[] for _ in range(instance["M"])]
+    constraints = [[] for _ in range(instance["ElementCount"])]
     for var_index, subset in enumerate(instance["Subsets"]):
         for constr_index in subset:
             constraints[constr_index].append(x_vars[var_index])


### PR DESCRIPTION
Thi is leftover from when instance formt was changed:

> commit 573b7ad44943876335f2e0abd89e2a8b5b6f471c
> Author: Douglas Wayne Potter <douglaspotter@gmail.com>
> Date:   Fri Nov 8 22:18:18 2024 +0100
>
>    refactor: rename M to ElementCount
>
>    This is to prefer more descriptive names in the exported structs and fields.
>
>   Also the use of the `ElementCount` is commented in the `README.md` code
>    example.